### PR TITLE
fix(commit callback): make error optional

### DIFF
--- a/src/@types/commitizen/index.d.ts
+++ b/src/@types/commitizen/index.d.ts
@@ -21,9 +21,18 @@ declare module "commitizen" {
   export interface IAdapter {
     prompter: (
       inquirer: Inquirer,
+      
+      /**
+       * This is a little hacky!
+       * The first parameter, the error, is optional. If there is no error, 
+       * the first parameter is the template and the second one beckomes the overrideOptions
+       * @param errorOrTemplate error of type Error, otherwise the template
+       * @param templateOrOverrideOptions if there is an error, this is the template, if there is no error, here should go overrideOptions
+       * @param overrideOptions only used, when there is an error, then here goes the override options.
+       */
       commit: (
-        error: Error | null,
-        template: string,
+        errorOrTemplate: Error | string,
+        templateOrOverrideOptions?: string | unknown,
         overrideOptions?: unknown
       ) => unknown
     ) => void;

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -24,8 +24,8 @@ export class Adapter implements IAdapter {
   async prompter(
     inquirer: Inquirer,
     commit: (
-      error: Error | null,
-      template: string,
+      errorOrTemplate: Error | string,
+      templateOrOverrideOptions?: string | unknown,
       overrideOptions?: unknown
     ) => unknown
   ): Promise<void> {
@@ -45,10 +45,7 @@ export class Adapter implements IAdapter {
 
     const answers: Answers = await inquirer.prompt(questions);
 
-    commit(
-      null,
-      formatCommitMessage(answers, this.configuration.maxLineWidth!)
-    );
+    commit(formatCommitMessage(answers, this.configuration.maxLineWidth!));
   }
 
   private jiraQuestion(): InputQuestion {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ const adapter = new Adapter(config);
 export function prompter(
   inquirer: Inquirer,
   commit: (
-    error: Error | null,
-    template: string,
+    errorOrTemplate: Error | string,
+    templateOrOverrideOptions?: string | unknown,
     overrideOptions?: unknown
   ) => unknown
 ): Promise<void> {


### PR DESCRIPTION
the commit callback has a different signature than i thought it has. it is a little hacky, so i
commented it in the declaration.